### PR TITLE
Fix duplicate limits in the list in paginator when the user changes limit

### DIFF
--- a/src/app/pages/components/contractor/contractor.component.html
+++ b/src/app/pages/components/contractor/contractor.component.html
@@ -70,4 +70,11 @@
     </tbody>
   </table>
 </div>
-<app-paginator [total]="total" [count]="count" [start]="start" (startChange)="onStartChange($event)" (countChange)="onCountChange($event)"></app-paginator>
+<app-paginator
+  [total]="total"
+  [count]="count"
+  [start]="start"
+  [limits]="limits"
+  (startChange)="onStartChange($event)"
+  (countChange)="onCountChange($event)"
+></app-paginator>

--- a/src/app/pages/components/contractor/contractor.component.ts
+++ b/src/app/pages/components/contractor/contractor.component.ts
@@ -14,7 +14,8 @@ export class ContractorComponent implements OnInit {
   contractors: Contractor[] = [];
   total: number = 0;
   start = 0;
-  count = 10;
+  limits = [10, 15, 25, 50, 100];
+  count = this.limits[0];
 
   @Input() generateContractors = true;
 

--- a/src/app/pages/components/paginator/paginator.component.ts
+++ b/src/app/pages/components/paginator/paginator.component.ts
@@ -9,7 +9,7 @@ export class PaginatorComponent implements OnInit, OnChanges {
   @Input() total = 0;
   @Input() count = 0;
   @Input() start = 0;
-  @Input() limits: number[] = [10, 15, 25, 50, 100];
+  @Input() limits: number[] = [10, 50, 100];
 
   @Output() startChange = new EventEmitter<number>();
   @Output() countChange = new EventEmitter<number>();
@@ -20,11 +20,7 @@ export class PaginatorComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['count']) {
-      if (!this.limits.includes(this.count)) {
-        this.limits = [...this.limits, this.count].sort((a, b) => a - b);
-      }
-    }
+
   }
 
   get first(): number {
@@ -63,8 +59,8 @@ export class PaginatorComponent implements OnInit, OnChanges {
     this.startChange.emit(page * this.count);
   }
 
-  newCountSelected(count: number): void {
-    this.countChange.emit(count);
+  newCountSelected(count: number | string): void {
+    this.countChange.emit(+count);
   }
   
   userPage(page: number ): number {


### PR DESCRIPTION
This PR fixes a bug when duplicate limits appear in the list in paginator when the user changes limit.